### PR TITLE
Add mobx as explicit dependency

### DIFF
--- a/visualization-core/package.json
+++ b/visualization-core/package.json
@@ -29,6 +29,7 @@
 	"dependencies": {
 		"@hediet/semantic-json": "^0.3.15",
 		"@hediet/std": "^0.6.0",
+		"mobx": "^6.3.2",
 		"react": "^16.12.0",
 		"react-dom": "^16.12.0",
 		"react-measure": "^2.3.0"


### PR DESCRIPTION
`mobx` is imported by [`VisualizerRegistry`](https://github.com/hediet/visualization/blob/fdd4927a5098815fde89d0e1337da094158e072d/visualization-core/src/VisualizerRegistry.ts#L4) but is not listed in `package.json`. This breaks usage of `@hediet/visualization-core` on [Skypack](https://www.skypack.dev/).

![image](https://user-images.githubusercontent.com/2266187/123708088-ae9c5980-d81f-11eb-818a-0a44c804a928.png)
