### PR TITLE
Fix mobx dependency

### DIFF
--- a/visualization-core/package.json
+++ b/visualization-core/package.json
@@ -29,7 +29,7 @@
 	"dependencies": {
 		"@hediet/semantic-json": "^0.3.15",
 		"@hediet/std": "^0.6.0",
-		"mobx": "^6.3.2",
+		"mobx": "^5.15.4",
 		"react": "^16.12.0",
 		"react-dom": "^16.12.0",
 		"react-measure": "^2.3.0"


### PR DESCRIPTION
2fcb84a84d0 broke the [build](https://github.com/hediet/visualization/runs/2939479726).

```
Error: [mobx] There are multiple, different versions of MobX active. Make sure MobX is loaded only once or use `configure({ isolateGlobalState: true })`
```

## Test Plan
`yarn build` from root directory. Run and use playground.